### PR TITLE
Issue 7 - Generated bindings have duplicate ___method_ptr variables 

### DIFF
--- a/bindgen/graph/api.odin
+++ b/bindgen/graph/api.odin
@@ -154,7 +154,7 @@ ApiClassProperty :: struct {
 }
 
 ApiClassMethod :: struct {
-    name:               string `json:"string"`,
+    name:               string `json:"name"`,
     is_vararg:          bool `json:"is_vararg"`,
     is_const:           bool `json:"is_const"`,
     is_static:          bool `json:"is_static"`,


### PR DESCRIPTION
The binding generator was producing duplicate `___method_ptr` variable declarations in generated .gen.odin files, causing Odin compilation errors. Trying to compile hello-gdextension:

`odin check examples/hello-gdextension/src/ -collection:godot=. -no-entry-point`

Produces this error:
`Error: Redeclaration of '___method_ptr' in this scope`

The issue was in  `bindgen/graph/api.odin` where the JSON parsing tags were incorrect, causing method names to be empty when parsing the Godot extension API JSON, resulting in the template generating `___method_ptr` for all methods instead of unique names. 

The compilation now returns with exit code 0, no errors. This fixes #7 