### PR TITLE
Fix malformed method names in builtin class generation

### DIFF
--- a/bindgen/graph/api.odin
+++ b/bindgen/graph/api.odin
@@ -94,7 +94,7 @@ ApiClassOperator :: struct {
 }
 
 ApiBuiltinClassMethod :: struct {
-    name:        string `json:"string"`,
+    name:        string `json:"name"`,
     return_type: Maybe(string) `json:"return_type"`,
     is_vararg:   bool `json:"is_vararg"`,
     is_const:    bool `json:"is_const"`,


### PR DESCRIPTION
Fixes #14

Aabb.gen.odin after the change:
```odin
aabb_aabb_abs :: proc "contextless" (
    self: ^Aabb,
) -> (ret: Aabb) {
    @(static) __ptr: __bindgen_gde.PtrBuiltInMethod
    if __ptr == nil {
        _gde_name := new_string_name_cstring("aabb_abs", true)
        __ptr = __bindgen_gde.variant_get_ptr_builtin_method(.Aabb, &_gde_name, 1576868580)
    }
    args := []__bindgen_gde.TypePtr {
    }
    __ptr(self, raw_data(args), &ret, len(args))
    return
}
aabb_aabb_get_center :: proc "contextless" (
    self: ^Aabb,
) -> (ret: Vector3) {
    @(static) __ptr: __bindgen_gde.PtrBuiltInMethod
    if __ptr == nil {
        _gde_name := new_string_name_cstring("aabb_get_center", true)
        __ptr = __bindgen_gde.variant_get_ptr_builtin_method(.Aabb, &_gde_name, 1776574132)
    }
    args := []__bindgen_gde.TypePtr {
    }
    __ptr(self, raw_data(args), &ret, len(args))
    return
}
aabb_aabb_get_volume :: proc "contextless" (
    self: ^Aabb,
) -> (ret: f32) {
    @(static) __ptr: __bindgen_gde.PtrBuiltInMethod
    if __ptr == nil {
        _gde_name := new_string_name_cstring("aabb_get_volume", true)
        __ptr = __bindgen_gde.variant_get_ptr_builtin_method(.Aabb, &_gde_name, 466405837)
    }
    args := []__bindgen_gde.TypePtr {
    }
    __ptr(self, raw_data(args), &ret, len(args))
    return
}
```